### PR TITLE
Display deprecation version at top-level.

### DIFF
--- a/components/src/grid/item/deprecated.css
+++ b/components/src/grid/item/deprecated.css
@@ -10,6 +10,12 @@ main > ul > li .deprecated > p {
     [display:var(--deprecated-warning-text-display)];
 }
 
+main > ul > li .deprecated > p .sub-dep {
+  @apply block uppercase cursor-pointer relative
+    [font-size:11px]
+    hover:opacity-70 text-right font-bold;
+}
+
 main > ul > li .deprecated > span {
   @apply h-4 w-4 mr-1 bg-warning-icon bg-left;
 }

--- a/components/src/grid/item/deprecated.rs
+++ b/components/src/grid/item/deprecated.rs
@@ -24,6 +24,11 @@ pub fn IconIsDeprecatedNotice(
         >
             <span></span>
             <p>{move_tr!("deprecated")}</p>
+            <p class="sub-dep">{move_tr!("removed-at-version", &{
+                let mut map = HashMap::new();
+                map.insert("version".to_string(), removal_at_version.into());
+                map
+            })}</p>
         </a>
     }
 }

--- a/i18n/locales/en-US/main.ftl
+++ b/i18n/locales/en-US/main.ftl
@@ -60,3 +60,4 @@ error-generating-pdf = Error generating PDF with PDFKit library:
 view-icon = View { $icon }
 copy-hex-color = Copy hex color
 discord = Discord
+removed-at-version = Removal at v{ $version }


### PR DESCRIPTION
This should (hopefully, I can't get the `cargo make` command working) display the deprecation version at the top level (without having to hover) replicating the behaviour of the current site.