### PR TITLE
Add explicit sizes to icon images of the grid

### DIFF
--- a/components/src/grid/item/icon_preview.rs
+++ b/components/src/grid/item/icon_preview.rs
@@ -46,7 +46,7 @@ pub fn IconGridItemPreview(
     });
     view! {
         <button title=button_title on:click=on_click_copy_image_children_src_content>
-            <img src=format!("/icons/{}.svg", slug) alt=img_alt/>
+            <img src=format!("/icons/{}.svg", slug) alt=img_alt width=56 height=56/>
         </button>
     }
 }


### PR DESCRIPTION
![image](https://github.com/mondeja/simple-icons-website-rs/assets/23049315/7bf3a6fa-ba93-4676-bac1-61b7949a71c0)
