### PR TITLE
Hide `Choose File` file input on Safari

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,9 +1292,9 @@ dependencies = [
 
 [[package]]
 name = "leptos-fluent"
-version = "0.0.32"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78022b4b0ac39783ee061bf059705363b4fb8698dada9d38deb18994fb40e81"
+checksum = "b517eba145ce71f029b94e8a25df6b8f726220dd83a2b073f6b69ab74eb16574"
 dependencies = [
  "fluent-templates",
  "leptos",
@@ -1305,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "leptos-fluent-macros"
-version = "0.0.32"
+version = "0.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdca228ffa0d2a433d3637624ed77b6e2dc073aa24b219dab0951ac64b0bcd8b"
+checksum = "0f603ca1f598fe4e58b4f02f337579b6d294bd4c9a03a5ce467f6a47d25878d2"
 dependencies = [
  "fluent-syntax",
  "fluent-templates",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ leptos_router = { version = "0.6.9", default-features = false, features = [
     "nightly"
 ] }
 leptos-use = "0.10.5"
-leptos-fluent = "0.0.32"
+leptos-fluent = "0.0.34"
 leptos_hotkeys = "0.2.1"
 leptos_icons = "0.3.0"
 icondata = "0.3.0"

--- a/components/src/preview_generator/buttons.rs
+++ b/components/src/preview_generator/buttons.rs
@@ -112,13 +112,15 @@ fn PreviewUploadSVGButton(
         }
     }
 
+    // File input hiding needs `max-w-0` and/or `invisible` on Safari:
+
     view! {
         <form class="inline-block">
             <input
                 type="file"
                 name="upload-svg"
                 accept=".svg"
-                class="absolute w-0 h-0 -z-index-1"
+                class="fixed right-full bottom-full max-w-0 max-h-0 w-0 h-0 overflow-hidden -z-10 invisible"
                 id=input_id
                 on:change=move |ev| {
                     let input = event_target::<web_sys::HtmlInputElement>(&ev);


### PR DESCRIPTION
Fixes #234